### PR TITLE
Sanitized count statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ An example implementation of the [text-analysis][text-analysis] project.
 2. `sample_data` is a directory containing sample text files to analyze, mostly from [Project Gutenberg](http://www.gutenberg.org/).
 
 [text-analysis]:https://github.com/codeunion/text-analysis
+
+## Usage
+
+Run the tests with the command-line argument `test`.
+
+```shell-session
+$ ruby textalyze.rb test
+```

--- a/textalyze.rb
+++ b/textalyze.rb
@@ -1,28 +1,3 @@
-# This is the base code for v0.1 of our Ruby text analyzer.
-# Visit https://github.com/codeunion/text-analysis/wiki to see what to do.
-#
-# Send an email to your cohort mailing list if you have any questions
-# or you're stuck!  These comments are here to help you, but please delete them
-# as you go along. You wouldn't normally have such heavily-commented code.
-
-# Method name: item_counts
-# Input:   An arbitrary array
-#
-# Returns: A hash where every item is a key whose value is the number of times
-#          that item appears in the array
-#
-# Prints:  Nothing
-
-# Here are some examples:
-#     item_counts(["I", "am", "Sam", "I", "am"])
-#       # => {"I" => 2, "am" => 2, "Sam" => 1}
-#
-#     item_counts([10, 20, 10, 20, 20])
-#       # => {10 => 2, 20 => 3}
-#
-# In short, item_counts(array) tells us how many times each item appears
-# in the input array.
-
 def item_counts(array)
   counts = {} # Initialize counts to an empty Hash
 
@@ -36,31 +11,9 @@ def item_counts(array)
   counts # This returns the "counts" hash
 end
 
-# "p" prints something to the screen in a way that's friendlier
-# for debugging purposes than print or puts.
-
 p item_counts([1,2,1,2,1]) == {1 => 3, 2 => 2}
 p item_counts(["a","b","a","b","a","ZZZ"]) == {"a" => 3, "b" => 2, "ZZZ" => 1}
 p item_counts([]) == {}
 p item_counts(["hi", "hi", "hi"]) == {"hi" => 3}
 p item_counts([true, nil, "dinosaur"]) == {true => 1, nil => 1, "dinosaur" => 1}
 p item_counts(["a","a","A","A"]) == {"a" => 2, "A" => 2}
-
-# Each of the lines above will print out "true" or "false" and collectively
-# act as a sanity check.  Remember that conceptually "x == y"
-# means "are x and y equal?"
-#
-# That is, when you run the code, if any lines print out "false"
-# then you know something is off in your code.
-#
-# This does *not* mean that your code is perfect if each line
-# prints out "true.""  For example,
-#   1. We might have missed a corner case
-#   2. The code does what it should, but is conceptually confused
-#   3. Something else we haven't though of
-#
-# Remember: Option #3 is *always* possible.
-#
-# Think of these like rumble strips on the side of the road.  They're here
-# to tell you when you're veering off the road, not to guarantee you're
-# driving phenomenally. :)

--- a/textalyze.rb
+++ b/textalyze.rb
@@ -8,6 +8,10 @@ def item_counts(array)
   counts
 end
 
+def chars_in(string)
+  string.chars
+end
+
 def format_counts(counts)
   counts.map do |item, count|
     "#{item} - #{count}"
@@ -21,6 +25,10 @@ if ARGV[0] == "test"
   p item_counts(["hi", "hi", "hi"]) == {"hi" => 3}
   p item_counts([true, nil, "dinosaur"]) == {true => 1, nil => 1, "dinosaur" => 1}
   p item_counts(["a","a","A","A"]) == {"a" => 2, "A" => 2}
+
+  p chars_in("a") == ["a"]
+  p chars_in("abc") == ["a", "b", "c"]
+  p chars_in("Dr. 123\n") == ["D", "r", ".", " ", "1", "2", "3", "\n"]
 
   sample_items = ["a", "a", "a", "b", "b", "c"]
 

--- a/textalyze.rb
+++ b/textalyze.rb
@@ -30,8 +30,11 @@ if ARGV[0] == "test"
   p chars_in("abc") == ["a", "b", "c"]
   p chars_in("Dr. 123\n") == ["D", "r", ".", " ", "1", "2", "3", "\n"]
 
-  sample_items = ["a", "a", "a", "b", "b", "c"]
+  sample_string = "Elementary, my dear Watson"
+  characters    = chars_in(sample_string)
+  char_counts   = item_counts(characters)
 
-  puts "The counts for #{sample_items} are..."
-  puts format_counts( item_counts(sample_items) )
+  puts "The counts for #{sample_string} are..."
+
+  puts format_counts( char_counts )
 end

--- a/textalyze.rb
+++ b/textalyze.rb
@@ -12,6 +12,10 @@ def chars_in(string)
   string.chars
 end
 
+def sanitize(string)
+  string.downcase
+end
+
 def format_counts(counts)
   counts.map do |item, count|
     "#{item} - #{count}"
@@ -30,8 +34,11 @@ if ARGV[0] == "test"
   p chars_in("abc") == ["a", "b", "c"]
   p chars_in("Dr. 123\n") == ["D", "r", ".", " ", "1", "2", "3", "\n"]
 
+  p sanitize("AaBbCc") == "aabbcc"
+  p sanitize("A- lOT. of cRaZy") == "a- lot. of crazy"
+
   sample_string = "Elementary, my dear Watson"
-  characters    = chars_in(sample_string)
+  characters    = chars_in( sanitize(sample_string) )
   char_counts   = item_counts(characters)
 
   puts "The counts for #{sample_string} are..."

--- a/textalyze.rb
+++ b/textalyze.rb
@@ -8,6 +8,12 @@ def item_counts(array)
   counts
 end
 
+def format_counts(counts)
+  counts.map do |item, count|
+    "#{item} - #{count}"
+  end.join("\n")
+end
+
 if ARGV[0] == "test"
   p item_counts([1,2,1,2,1]) == {1 => 3, 2 => 2}
   p item_counts(["a","b","a","b","a","ZZZ"]) == {"a" => 3, "b" => 2, "ZZZ" => 1}
@@ -15,4 +21,9 @@ if ARGV[0] == "test"
   p item_counts(["hi", "hi", "hi"]) == {"hi" => 3}
   p item_counts([true, nil, "dinosaur"]) == {true => 1, nil => 1, "dinosaur" => 1}
   p item_counts(["a","a","A","A"]) == {"a" => 2, "A" => 2}
+
+  sample_items = ["a", "a", "a", "b", "b", "c"]
+
+  puts "The counts for #{sample_items} are..."
+  puts format_counts( item_counts(sample_items) )
 end

--- a/textalyze.rb
+++ b/textalyze.rb
@@ -1,3 +1,10 @@
+def textalyze(text)
+  characters  = chars_in( sanitize(text) )
+  char_counts = item_counts(characters)
+
+  format_counts(char_counts)
+end
+
 def item_counts(array)
   counts = Hash.new(0)
 
@@ -41,10 +48,6 @@ if ARGV[0] == "test"
   p sanitize("A- lOT. of cRaZy") == "a- lot. of crazy"
 
   sample_string = "Elementary, my dear Watson"
-  characters    = chars_in( sanitize(sample_string) )
-  char_counts   = item_counts(characters)
-
   puts "The counts for #{sample_string} are..."
-
-  puts format_counts( char_counts )
+  puts textalyze(sample_string)
 end

--- a/textalyze.rb
+++ b/textalyze.rb
@@ -30,6 +30,9 @@ if ARGV[0] == "test"
   p item_counts([true, nil, "dinosaur"]) == {true => 1, nil => 1, "dinosaur" => 1}
   p item_counts(["a","a","A","A"]) == {"a" => 2, "A" => 2}
 
+  p format_counts({"a" => 2, "A" => 2}) == "a - 2\nA - 2"
+  p format_counts({true => 1, nil => 1, "dinosaur" => 1}) == "true - 1\n - 1\ndinosaur - 1"
+
   p chars_in("a") == ["a"]
   p chars_in("abc") == ["a", "b", "c"]
   p chars_in("Dr. 123\n") == ["D", "r", ".", " ", "1", "2", "3", "\n"]

--- a/textalyze.rb
+++ b/textalyze.rb
@@ -8,9 +8,11 @@ def item_counts(array)
   counts
 end
 
-p item_counts([1,2,1,2,1]) == {1 => 3, 2 => 2}
-p item_counts(["a","b","a","b","a","ZZZ"]) == {"a" => 3, "b" => 2, "ZZZ" => 1}
-p item_counts([]) == {}
-p item_counts(["hi", "hi", "hi"]) == {"hi" => 3}
-p item_counts([true, nil, "dinosaur"]) == {true => 1, nil => 1, "dinosaur" => 1}
-p item_counts(["a","a","A","A"]) == {"a" => 2, "A" => 2}
+if ARGV[0] == "test"
+  p item_counts([1,2,1,2,1]) == {1 => 3, 2 => 2}
+  p item_counts(["a","b","a","b","a","ZZZ"]) == {"a" => 3, "b" => 2, "ZZZ" => 1}
+  p item_counts([]) == {}
+  p item_counts(["hi", "hi", "hi"]) == {"hi" => 3}
+  p item_counts([true, nil, "dinosaur"]) == {true => 1, nil => 1, "dinosaur" => 1}
+  p item_counts(["a","a","A","A"]) == {"a" => 2, "A" => 2}
+end

--- a/textalyze.rb
+++ b/textalyze.rb
@@ -20,7 +20,7 @@ def chars_in(string)
 end
 
 def sanitize(string)
-  string.downcase
+  string.downcase.gsub(/[^a-z0-9\s]/, '')
 end
 
 def format_counts(counts)
@@ -45,7 +45,10 @@ if ARGV[0] == "test"
   p chars_in("Dr. 123\n") == ["D", "r", ".", " ", "1", "2", "3", "\n"]
 
   p sanitize("AaBbCc") == "aabbcc"
-  p sanitize("A- lOT. of cRaZy") == "a- lot. of crazy"
+  p sanitize("A- lOT. of cRaZy") == "a lot of crazy"
+  p sanitize("This is a sentence.") == "this is a sentence"
+  p sanitize("WHY AM I YELLING?") == "why am i yelling"
+  p sanitize("HEY: ThIs Is hArD tO rEaD!") == "hey this is hard to read"
 
   sample_string = "Elementary, my dear Watson"
   puts "The counts for #{sample_string} are..."

--- a/textalyze.rb
+++ b/textalyze.rb
@@ -1,14 +1,11 @@
 def item_counts(array)
-  counts = {} # Initialize counts to an empty Hash
+  counts = Hash.new(0)
 
   array.each do |item|
-    # Add code here to modify the "counts" hash accordingly
-    # You'll need to handle two cases:
-    #   1. The first time we've seen a particular item in the array
-    #   2. The second-or-later time we've seen a particular item in the array
+    counts[item] += 1
   end
 
-  counts # This returns the "counts" hash
+  counts
 end
 
 p item_counts([1,2,1,2,1]) == {1 => 3, 2 => 2}


### PR DESCRIPTION
Implements versions 0.1-0.3.

Not fully functional yet. Currently a collection of analysis methods:
- `textalyze()` : takes a string and returns a formatted list of characters and their count
- `item_counts()` : takes an array and returns a hash of item/count pairs
- `chars_in()` : takes a string as input and returns an array of all characters
  in that string, including punctuation and whitespace
- `sanitize()` : removes unwanted characters from a string and converts to lower case
- `format_counts()` : takes a hash of item/count pairs and returns a nicely formatted string
